### PR TITLE
Integrate with WooCommerce

### DIFF
--- a/altcha.php
+++ b/altcha.php
@@ -68,6 +68,7 @@ require plugin_dir_path( __FILE__ ) . './integrations/gravityforms.php';
 require plugin_dir_path( __FILE__ ) . './integrations/wpdiscuz.php';
 require plugin_dir_path( __FILE__ ) . './integrations/wpforms.php';
 require plugin_dir_path( __FILE__ ) . './integrations/wpmembers.php';
+require plugin_dir_path( __FILE__ ) . './integrations/woocommerce.php';
 require plugin_dir_path( __FILE__ ) . './integrations/wordpress.php';
 
 AltchaPlugin::$widget_script_src = plugin_dir_url(__FILE__) . "public/altcha.min.js";

--- a/includes/core.php
+++ b/includes/core.php
@@ -58,6 +58,12 @@ class AltchaPlugin
 
   public static $option_integration_gravityforms = "altcha_integration_gravityforms";
 
+  public static $option_integration_woocommerce_login = "altcha_integration_woocommerce_login";
+
+  public static $option_integration_woocommerce_register = "altcha_integration_woocommerce_register";
+
+  public static $option_integration_woocommerce_reset_password = "altcha_integration_woocommerce_reset_password";
+
   public static $option_integration_html_forms = "altcha_integration_html_forms";
 
   public static $option_integration_wordpress_login = "altcha_integration_wordpress_login";
@@ -202,6 +208,21 @@ class AltchaPlugin
     return trim(get_option(AltchaPlugin::$option_integration_gravityforms));
   }
 
+  public function get_integration_woocommerce_register()
+  {
+    return trim(get_option(AltchaPlugin::$option_integration_woocommerce_register));
+  }
+
+  public function get_integration_woocommerce_reset_password()
+  {
+    return trim(get_option(AltchaPlugin::$option_integration_woocommerce_reset_password));
+  }
+
+  public function get_integration_woocommerce_login()
+  {
+    return trim(get_option(AltchaPlugin::$option_integration_woocommerce_login));
+  }
+
   public function get_integration_html_forms()
   {
     return trim(get_option(AltchaPlugin::$option_integration_html_forms));
@@ -281,6 +302,9 @@ class AltchaPlugin
       $this->get_integration_forminator(),
       $this->get_integration_gravityforms(),
       $this->get_integration_html_forms(),
+      $this->get_integration_woocommerce_register(),
+      $this->get_integration_woocommerce_login(),
+      $this->get_integration_woocommerce_reset_password(),
       $this->get_integration_wordpress_register(),
       $this->get_integration_wordpress_login(),
       $this->get_integration_wordpress_reset_password(),

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -99,6 +99,21 @@ if (is_admin()) {
 
     register_setting(
       'altcha_options',
+      AltchaPlugin::$option_integration_woocommerce_login
+    );
+
+    register_setting(
+      'altcha_options',
+      AltchaPlugin::$option_integration_woocommerce_register
+    );
+
+    register_setting(
+      'altcha_options',
+      AltchaPlugin::$option_integration_woocommerce_reset_password
+    );
+
+    register_setting(
+      'altcha_options',
       AltchaPlugin::$option_integration_html_forms
     );
 
@@ -498,6 +513,63 @@ if (is_admin()) {
             "disabled" => !altcha_plugin_active('wpforms'),
             "spamfilter_options" => array(
               "spamfilter",
+              "captcha_spamfilter",
+            ),
+            "options" => array(
+              "" => "Disable",
+              "captcha" => "Captcha",
+              "captcha_spamfilter" => "Captcha + Spam Filter",
+            ),
+        )
+    );
+
+    add_settings_field(
+        'altcha_settings_woocommerce_register_integration_field',
+        'WooCommerce register page',
+        'altcha_settings_select_callback',
+        'altcha_admin',
+        'altcha_integrations_settings_section',
+        array(
+            "name" => AltchaPlugin::$option_integration_woocommerce_register,
+            "spamfilter_options" => array(
+              "captcha_spamfilter",
+            ),
+            "options" => array(
+              "" => "Disable",
+              "captcha" => "Captcha",
+              "captcha_spamfilter" => "Captcha + Spam Filter",
+            ),
+        )
+    );
+
+    add_settings_field(
+        'altcha_settings_woocommerce_reset_password_integration_field',
+        'WooCommerce reset password page',
+        'altcha_settings_select_callback',
+        'altcha_admin',
+        'altcha_integrations_settings_section',
+        array(
+            "name" => AltchaPlugin::$option_integration_woocommerce_reset_password,
+            "spamfilter_options" => array(
+              "captcha_spamfilter",
+            ),
+            "options" => array(
+              "" => "Disable",
+              "captcha" => "Captcha",
+              "captcha_spamfilter" => "Captcha + Spam Filter",
+            ),
+        )
+    );
+
+    add_settings_field(
+        'altcha_settings_woocommerce_login_integration_field',
+        'WooCommerce login page',
+        'altcha_settings_select_callback',
+        'altcha_admin',
+        'altcha_integrations_settings_section',
+        array(
+            "name" => AltchaPlugin::$option_integration_woocommerce_login,
+            "spamfilter_options" => array(
               "captcha_spamfilter",
             ),
             "options" => array(

--- a/integrations/woocommerce.php
+++ b/integrations/woocommerce.php
@@ -1,0 +1,130 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+add_action(
+  'woocommerce_register_form',
+  function () {
+    $plugin = AltchaPlugin::$instance;
+    $mode = $plugin->get_integration_woocommerce_register();
+    if (!empty($mode)) {
+      altcha_woocommerce_comments_render_widget($mode, 'altcha_register');
+    }
+  },
+  10,
+  0
+);
+
+add_action(
+  'woocommerce_register_post',
+  function ($user_login, $user_email, $errors) {
+    $plugin = AltchaPlugin::$instance;
+    $mode = $plugin->get_integration_woocommerce_register();
+    if (!empty($mode)) {
+      $altcha = isset($_POST['altcha_register']) ? trim(sanitize_text_field($_POST['altcha_register'])) : '';
+      if ($plugin->verify($altcha) === false) {
+        return $errors->add(
+          'altcha_error_message',
+          esc_html__('Could not verify you are not a robot.', 'altcha-spam-protection')
+        );
+      }
+    }
+    return $errors;
+  },
+  10,
+  3
+);
+
+add_action(
+  'woocommerce_login_form',
+  function () {
+    $plugin = AltchaPlugin::$instance;
+    $mode = $plugin->get_integration_woocommerce_login();
+    if (!empty($mode)) {
+      altcha_woocommerce_comments_render_widget($mode);
+    }
+  },
+  10,
+  0
+);
+
+add_filter(
+  'authenticate',
+  function ($user) {
+    if ($user instanceof WP_Error) {
+      return $user;
+    }
+    if(defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST) {
+      return $user; // Skip XMLRPC
+    }
+    if(defined( 'REST_REQUEST' ) && REST_REQUEST) {
+      return $user; // Skip REST API
+    }
+    if(!isset($_POST['woocommerce-login-nonce'])) {
+      return $user; // Only handle WooCommerce form submissions
+    }
+
+    $plugin = AltchaPlugin::$instance;
+    $mode = $plugin->get_integration_woocommerce_login();
+    if (!empty($mode)) {
+      $altcha = isset($_POST['altcha']) ? trim(sanitize_text_field($_POST['altcha'])) : '';
+      if ($plugin->verify($altcha) === false) {
+        return new WP_Error(
+          'altcha-error',
+          esc_html__('Could not verify you are not a robot.', 'altcha-spam-protection')
+        );
+      }
+    }
+    return $user;
+  },
+  20,
+  1
+);
+
+add_action(
+  'woocommerce_lostpassword_form',
+  function () {
+    $plugin = AltchaPlugin::$instance;
+    $mode = $plugin->get_integration_woocommerce_reset_password();
+    if (!empty($mode)) {
+      altcha_woocommerce_comments_render_widget($mode);
+    }
+  },
+  10,
+  0
+);
+
+add_filter(
+  'lostpassword_post',
+  function ($errors) {
+    if (is_user_logged_in()) {
+      return $errors;
+    }
+    // Only handle WooCommerce form submissions
+    if(!isset($_POST['woocommerce-lost-password-nonce'])) {
+      return $errors;
+    }
+    $plugin = AltchaPlugin::$instance;
+    $mode = $plugin->get_integration_woocommerce_reset_password();
+    if (!empty($mode)) {
+      $altcha = isset($_POST['altcha']) ? trim(sanitize_text_field($_POST['altcha'])) : '';
+      if ($plugin->verify($altcha) === false) {
+        $errors->add(
+          'altcha_error_message',
+          esc_html__('Could not verify you are not a robot.', 'altcha-spam-protection')
+        );
+      }
+    }
+    return $errors;
+  },
+  10,
+  1
+);
+
+function altcha_woocommerce_comments_render_widget($mode, $name = null)
+{
+  $plugin = AltchaPlugin::$instance;
+  altcha_enqueue_scripts();
+  altcha_enqueue_styles();
+  echo wp_kses($plugin->render_widget($mode, true, null, $name), AltchaPlugin::$html_espace_allowed_tags);
+}


### PR DESCRIPTION
Fixes #25

Note: WooCommerce does not have its own `authentication` and `lostpassword_post` hooks, but reuses those used by WordPress.

This means that even if the respective WP option is set, WC option would be implicitly required to be set, unless code in `wordpress.php` was modifed to account for this. On the other hand, if both options were set, Altcha response will be validated twice.

However, if only the respective WooCommerce option were set, the WordPress option would not be required (the altcha check function will ignore non-WooCommerce POST requests).