### PR TITLE
Add an error instead of calling wp_die() when submitting password lost form fails

### DIFF
--- a/integrations/forminator.php
+++ b/integrations/forminator.php
@@ -32,7 +32,7 @@ if (altcha_plugin_active('forminator')) {
           if ($plugin->verify($altcha) === false) {
             return [
               'can_submit' => false,
-              'error' => __('Cannot submit your message.', 'altcha-spam-protection'),
+              'error' => __('Could not verify you are not a robot.', 'altcha-spam-protection'),
             ];
           }
         }

--- a/integrations/gravityforms/field.php
+++ b/integrations/gravityforms/field.php
@@ -76,7 +76,7 @@ class ALTCHA_GFForms_Field extends GF_Field
         $altcha = isset($_POST['altcha']) ? trim(sanitize_text_field($_POST['altcha'])) : '';
 				if ($plugin->verify($altcha) === false) {
 					$this->failed_validation  = true;
-					$this->validation_message = __('Cannot submit your message.', 'altcha-spam-protection');
+					$this->validation_message = __('Could not verify you are not a robot.', 'altcha-spam-protection');
 				}
 			}
 		}

--- a/integrations/html-forms.php
+++ b/integrations/html-forms.php
@@ -46,14 +46,14 @@ if (altcha_plugin_active('html-forms')) {
   add_filter(
     'hf_form_message_altcha_invalid',
     function ($message) {
-      return __('Cannot submit your message.', 'altcha-spam-protection');
+      return __('Could not verify you are not a robot.', 'altcha-spam-protection');
     }
   );
 
   add_filter(
     'hf_form_message_altcha_spam',
     function ($message) {
-      return __('Cannot submit your message.', 'altcha-spam-protection');
+      return __('Could not verify you are not a robot.', 'altcha-spam-protection');
     }
   );
 }

--- a/integrations/wordpress.php
+++ b/integrations/wordpress.php
@@ -83,23 +83,26 @@ add_action(
 
 add_filter(
   'lostpassword_post',
-  function ($val) {
+  function ($errors) {
     if (is_user_logged_in()) {
-        return $val;
+      return $errors;
     }
     $plugin = AltchaPlugin::$instance;
     $mode = $plugin->get_integration_wordpress_reset_password();
     if (!empty($mode)) {
       $altcha = isset($_POST['altcha']) ? trim(sanitize_text_field($_POST['altcha'])) : '';
       if ($plugin->verify($altcha) === false) {
-        wp_die('<strong>' . esc_html__('Error', 'altcha-spam-protection') . '</strong> : ' . esc_html__('Could not verify you are not a robot.', 'altcha-spam-protection'));
+        $errors->add(
+          'altcha_error_message',
+          '<strong>' . esc_html__('Error', 'altcha-spam-protection') . '</strong> : ' . esc_html__('Could not verify you are not a robot.', 'altcha-spam-protection')
+        );
       }
     }
-    return $val;
+    return $errors;
   },
   10,
   1
-);	
+);
 
 add_action(
   'comment_form_after_fields',

--- a/integrations/wordpress.php
+++ b/integrations/wordpress.php
@@ -25,7 +25,7 @@ add_action(
       if ($plugin->verify($altcha) === false) {
         return $errors->add(
           'altcha_error_message',
-          '<strong>' . esc_html__('Error', 'altcha-spam-protection') . '</strong> : ' . esc_html__('Cannot submit your message.', 'altcha-spam-protection')
+          '<strong>' . esc_html__('Error', 'altcha-spam-protection') . '</strong> : ' . esc_html__('Could not verify you are not a robot.', 'altcha-spam-protection')
         );
       }
     }
@@ -59,7 +59,7 @@ add_filter(
     if (!empty($mode)) {
       $altcha = isset($_POST['altcha']) ? trim(sanitize_text_field($_POST['altcha'])) : '';
       if ($plugin->verify($altcha) === false) {
-        return new WP_Error("altcha-error", '<strong>' . esc_html__('Error', 'altcha-spam-protection') . '</strong> : ' . esc_html__('Cannot submit your message.', 'altcha-spam-protection'));
+        return new WP_Error("altcha-error", '<strong>' . esc_html__('Error', 'altcha-spam-protection') . '</strong> : ' . esc_html__('Could not verify you are not a robot.', 'altcha-spam-protection'));
       }
     }
     return $user;
@@ -92,7 +92,7 @@ add_filter(
     if (!empty($mode)) {
       $altcha = isset($_POST['altcha']) ? trim(sanitize_text_field($_POST['altcha'])) : '';
       if ($plugin->verify($altcha) === false) {
-        wp_die('<strong>' . esc_html__('Error', 'altcha-spam-protection') . '</strong> : ' . esc_html__('Cannot submit your message.', 'altcha-spam-protection'));
+        wp_die('<strong>' . esc_html__('Error', 'altcha-spam-protection') . '</strong> : ' . esc_html__('Could not verify you are not a robot.', 'altcha-spam-protection'));
       }
     }
     return $val;
@@ -139,7 +139,7 @@ add_filter(
     if (!empty($mode)) {
       $altcha = isset($_POST['altcha']) ? trim(sanitize_text_field($_POST['altcha'])) : '';
       if ($plugin->verify($altcha) === false) {
-        wp_die('<strong>' . esc_html__('Error', 'altcha-spam-protection') . '</strong> : ' . esc_html__('Cannot submit your message.', 'altcha-spam-protection'));
+        wp_die('<strong>' . esc_html__('Error', 'altcha-spam-protection') . '</strong> : ' . esc_html__('Could not verify you are not a robot.', 'altcha-spam-protection'));
       }
     }
     return $comment;

--- a/integrations/wpforms.php
+++ b/integrations/wpforms.php
@@ -25,7 +25,7 @@ if (altcha_plugin_active('wpforms')) {
         if ($mode === "captcha" || $mode === "captcha_spamfilter") {
           $altcha = isset($_POST['altcha']) ? trim(sanitize_text_field($_POST['altcha'])) : '';
           if ($plugin->verify($altcha) === false) {
-            wpforms()->process->errors[$form_data['id']]['header'] = esc_html__('Cannot submit your message.', 'altcha-spam-protection');
+            wpforms()->process->errors[$form_data['id']]['header'] = esc_html__('Could not verify you are not a robot.', 'altcha-spam-protection');
           }
         }
       }


### PR DESCRIPTION
Not sure why the hook handler for the `lostpassword_post` currently calls `wp_die()` if Altcha verification fails when it could simply add an error to the object passed to it instead. This PR changes that.

This builds on #27, so please review that first.