### PR TITLE
Ignore WooCommerce form submissions in WordPress integration

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -14,6 +14,8 @@ function altcha_plugin_active($name) {
       return is_plugin_active('html-forms/html-forms.php');
     case 'contact-form-7':
       return is_plugin_active('contact-form-7/wp-contact-form-7.php');
+    case 'woocommerce':
+      return is_plugin_active('woocommerce/woocommerce.php');
     case 'wpdiscuz':
       return is_plugin_active('wpdiscuz/class.WpdiscuzCore.php');
     case 'wpmembers':

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -531,6 +531,7 @@ if (is_admin()) {
         'altcha_integrations_settings_section',
         array(
             "name" => AltchaPlugin::$option_integration_woocommerce_register,
+            "disabled" => !altcha_plugin_active('woocommerce'),
             "spamfilter_options" => array(
               "captcha_spamfilter",
             ),
@@ -550,6 +551,7 @@ if (is_admin()) {
         'altcha_integrations_settings_section',
         array(
             "name" => AltchaPlugin::$option_integration_woocommerce_reset_password,
+            "disabled" => !altcha_plugin_active('woocommerce'),
             "spamfilter_options" => array(
               "captcha_spamfilter",
             ),
@@ -569,6 +571,7 @@ if (is_admin()) {
         'altcha_integrations_settings_section',
         array(
             "name" => AltchaPlugin::$option_integration_woocommerce_login,
+            "disabled" => !altcha_plugin_active('woocommerce'),
             "spamfilter_options" => array(
               "captcha_spamfilter",
             ),

--- a/integrations/wordpress.php
+++ b/integrations/wordpress.php
@@ -54,6 +54,15 @@ add_filter(
     if ($user instanceof WP_Error) {
       return $user;
     }
+    if(defined('XMLRPC_REQUEST') && XMLRPC_REQUEST) {
+      return $user; // Skip XMLRPC
+    }
+    if(defined('REST_REQUEST') && REST_REQUEST) {
+      return $user; // Skip REST API
+    }
+    if(altcha_plugin_active('woocommerce') && isset($_POST['woocommerce-login-nonce'])) {
+      return $user; // WooCommerce form submissions are handled separately
+    }
     $plugin = AltchaPlugin::$instance;
     $mode = $plugin->get_integration_wordpress_login();
     if (!empty($mode)) {
@@ -86,6 +95,9 @@ add_filter(
   function ($errors) {
     if (is_user_logged_in()) {
       return $errors;
+    }
+    if(altcha_plugin_active('woocommerce') && isset($_POST['woocommerce-lost-password-nonce'])) {
+      return $errors; // WooCommerce form submissions are handled separately
     }
     $plugin = AltchaPlugin::$instance;
     $mode = $plugin->get_integration_wordpress_reset_password();


### PR DESCRIPTION
Adds to #26. I also copied the check for XMLRPC/REST request from the other plugin for the requests I edited.